### PR TITLE
New RegruClient constructor $options: path to log file, log level, guzzle timeout

### DIFF
--- a/src/RegruClient.php
+++ b/src/RegruClient.php
@@ -36,6 +36,16 @@ class RegruClient
     protected $password;
 
     /**
+     * @var string Path to log file
+     */
+    protected $log_path;
+
+    /**
+     * @var boolean Log level (log all requests or exceptions only)
+     */
+    protected $debug;
+
+    /**
      * @var string Имя категории функций апи
      */
     protected $categoryName;
@@ -84,6 +94,8 @@ class RegruClient
     {
         $this->username = $options['username'];
         $this->password = $options['password'];
+        $this->log_path = $options['log_path'];
+        $this->debug = $options['debug'];
 
         if (!empty($options['inputFormat'])) {
             $this->inputFormat = $options['inputFormat'];
@@ -103,8 +115,8 @@ class RegruClient
             $this->lang = 'ru';
         }
 
-        $log = new Logger('main');
-        $log->pushHandler(new StreamHandler(__DIR__ . '/../log/main.log', Logger::DEBUG));
+        $log = new Logger('regru');
+        $log->pushHandler(new StreamHandler($this->log_path, true === $this->debug ? Logger::DEBUG : Logger::ERROR));
 
         $log->pushProcessor(
             new \Monolog\Processor\ProcessIdProcessor()

--- a/src/RegruClient.php
+++ b/src/RegruClient.php
@@ -46,6 +46,11 @@ class RegruClient
     protected $debug;
 
     /**
+     * @var float Default Guzzle timeout (connect_timeout and timeout)
+     */
+    protected $timeout;
+
+    /**
      * @var string Имя категории функций апи
      */
     protected $categoryName;
@@ -96,6 +101,7 @@ class RegruClient
         $this->password = $options['password'];
         $this->log_path = $options['log_path'];
         $this->debug = $options['debug'];
+        $this->timeout = $options['timeout'];
 
         if (!empty($options['inputFormat'])) {
             $this->inputFormat = $options['inputFormat'];
@@ -170,7 +176,11 @@ class RegruClient
 
             $this->logger->debug("Calling $url with options: ".print_r(self::censor($post_params), true));
 
-            $raw = (string)$HttpClient->post($url, array('form_params' => $post_params))->getBody();
+            $raw = (string)$HttpClient->post($url, [
+                'form_params' => $post_params,
+                'connect_timeout' => null !== $this->timeout ? $this->timeout : 0,
+                'timeout' => null !== $this->timeout ? $this->timeout : 0,
+            ])->getBody();
 
             $this->logger->debug("Got result: ".$raw);
 


### PR DESCRIPTION
`$options['log_path']` - path to log file
`$options['debug']` - log level (log all requests or exceptions only)
`$options['timeout']` - default Guzzle timeout (`connect_timeout` and `timeout`)